### PR TITLE
Fix back

### DIFF
--- a/Backend/posts/serializers.py
+++ b/Backend/posts/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+from .models import Post, Notice
+
+class NoticeSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        model = Notice
+        fields = '__all__'
+        read_only_fields = ('author', 'study', 'created_at', 'updated_at')

--- a/Backend/posts/urls.py
+++ b/Backend/posts/urls.py
@@ -4,9 +4,7 @@ from . import views
 app_name = 'posts'
 
 urlpatterns = [
-    path('create_notice/', views.create_notice, name='create_notice'),
-    path('update_notice/', views.update_notice, name='update_notice'),
-    path('read_notice', views.read_notice, name='read_notice'),
-    path('delete_notice', views.delete_notice, name='delete_notice'),
+    path('create_notice/', views.notice_create, name='notice_create'),
+    path('notice_detail/<int:notice_id>', views.notice_detail, name='notice_detail'),
 
 ]

--- a/Backend/posts/views.py
+++ b/Backend/posts/views.py
@@ -65,7 +65,7 @@ def notice_detail(request, study_id, notice_id):
     if not membership:
         return error_list(NOT_MEMBER)
 
-    notice = get_object_or_404(Notice, id=notice_id)
+    notice = get_object_or_404(Notice, id=notice_id, study=study)
     
     # 공지사항 조회
     if request.method == 'GET':

--- a/Backend/posts/views.py
+++ b/Backend/posts/views.py
@@ -1,176 +1,205 @@
-from django.shortcuts import render, get_object_or_404
-from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.http import require_POST
 
-from .forms import NoticeCreationForm
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
+
 from .models import Notice, Post
 from studies.models import Study, StudyMembership
+from .serializers import NoticeSerializer
 
 # Create your views here.
 
-# 공지 작성
-@require_POST
+NOT_MEMBER = "NOT_MEMBER"
+NOT_AUTHORIZED = "NOT_AUTHORIZED"
+
+def error_list(code):
+    if code == "NOT_MEMBER":
+        return Response({"error": "스터디 멤버가 아닙니다."},
+                        status=status.HTTP_403_FORBIDDEN,
+                        json_dumps_params={"ensure_ascii": False})
+    elif code == 'NOT_AUTHORIZED':
+        return Response({"error": "권한이 없습니다."},
+                        status=status.HTTP_403_FORBIDDEN,
+                        json_dumps_params={"ensure_ascii": False})
+
 @login_required
-def create_notice(request):
+@api_view(['POST'])
+def notice_create(request):
     user = request.user
-    study_id = request.POST.get("study_id")
+    study_id = request.data.get("study_id")
     study = get_object_or_404(Study, id=study_id)
     membership = StudyMembership.objects.filter(
         user=user, study=study, is_active=True
-        ).first()
+    ).first()
+
+    # 외부인 거부
     if not membership:
-        return JsonResponse(
-            {"error": "스터디 멤버가 아닙니다."},
-            status=403,
-            json_dumps_params={"ensure_ascii": False}
-        )
-    if membership.role not in ('leader', 'admin'):
-        return JsonResponse(
-            {"error": "공지사항 작성 권한이 없습니다."},
-            status=403,
-            json_dumps_params={"ensure_ascii": False}
-        )
+        return error_list(NOT_MEMBER)
 
-    form = NoticeCreationForm(request.POST)
-    if form.is_valid():
-        notice = form.save(commit=False)
-        notice.study = study
-        notice.author = user
-        notice.save()
-        return JsonResponse(
-            {
-                "message": "공지사항이 작성되었습니다.",
-                "notice":{
-                    "id": notice.id,
-                    "title": notice.title,
-                    "content": notice.content,
-                    "study": study.name,
-                    "author": user.username,
-                    "created_at": notice.created_at.strftime("%Y-%m-%d %H:%M"),
-                }
-            },
-            status=201,
-            json_dumps_params={"ensure_ascii": False}
-        )
-    else:
-        return JsonResponse(
-            {"error": form.errors},
-            status=400,
-            json_dumps_params={"ensure_ascii": False}
-        )
+    # 공자사항 작성
+    if request.method == 'POST':
+        if membership.role not in ('leader', 'admin'):
+            return error_list(NOT_AUTHORIZED)
 
-# 공지 수정
-@require_POST
+        serializer = NoticeSerializer(data=request.data)
+        if serializer.is_valid():
+            notice = serializer.save(author = request.user, study = study)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
 @login_required
-def update_notice(request):
-    study_id = request.POST.get("study_id")
-    notice_id = request.POST.get("notice_id")
+@api_view(['GET', 'PUT', 'DELETE'])
+def notice_detail(request, study_id, notice_id):
+
     user = request.user
     study = get_object_or_404(Study, id=study_id)
-    notice = get_object_or_404(Notice, id=notice_id, study=study)
     membership = StudyMembership.objects.filter(
         user=user, study=study, is_active=True
-        ).first()
-    if not membership:
-        return JsonResponse(
-            {"error": "스터디 멤버가 아닙니다."},
-            status=403,
-            json_dumps_params={"ensure_ascii": False}
-        )
-    if membership.role not in ('leader', 'admin'):
-        return JsonResponse(
-            {"error": "공지사항 수정 권한이 없습니다."},
-            status=403,
-            json_dumps_params={"ensure_ascii": False}
-        )
-    # if notice.author != user:
-    #     return JsonResponse(
-    #         {"error": "본인만 수정 가능합니다."},
-    #         status=403
-    #     )
-    form = NoticeCreationForm(request.POST, instance=notice)
-    if form.is_valid():
-        form.save()
-        return JsonResponse(
-            {
-                "message": "공지사항이 수정되었습니다.",
-                "notice":{
-                    "id": notice.id,
-                    "title": notice.title,
-                    "content": notice.content,
-                    "study": study.name,
-                    "author": user.username,
-                    "created_at": notice.created_at.strftime("%Y-%m-%d %H:%M"),
-                    "updated_at": notice.updated_at.strftime("%Y-%m-%d %H:%M"),
-                }
-            },
-            status=200,
-            json_dumps_params={"ensure_ascii": False}
-        )
-    else:
-        return JsonResponse(
-            {"error": form.errors},
-            status=400,
-            json_dumps_params={"ensure_ascii": False}
-        )
+    ).first()
 
-# 공지 조회
-@login_required
-def read_notice(request):
-    study_id = request.GET.get("study_id")
-    notice_id = request.GET.get("notice_id")
-    user = request.user
-    study = get_object_or_404(Study, id=study_id)
-    notice = get_object_or_404(Notice, id=notice_id, study=study)
-    membership = StudyMembership.objects.filter(
-        user=user, study=study, is_active=True
-        ).first()
+    # 외부인 거부
     if not membership:
-        return JsonResponse({
-            "error": "스터디 멤버가 아닙니다.",
-        }, status=403, json_dumps_params={"ensure_ascii": False})
+        return error_list(NOT_MEMBER)
 
-    return JsonResponse({
-        "message": "조회 성공",
-        "notice": {
-            "id": notice.id,
-            "title": notice.title,
-            "content": notice.content,
-            "study": study.name,
-            "author": notice.author.username,
-            "created_at": notice.created_at.strftime("%Y-%m-%d %H:%M"),
-            "updated_at": notice.updated_at.strftime("%Y-%m-%d %H:%M"),
-        }
-    }, status=200, json_dumps_params={"ensure_ascii": False})
+    notice = get_object_or_404(Notice, id=notice_id)
+    
+    # 공지사항 조회
+    if request.method == 'GET':
+        serializer = NoticeSerializer(notice)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    # 공지사항 수정
+    elif request.method == 'PUT':
+        # if notice.author != user:
+        #     return Response(status=status.HTTP_403_FORBIDDEN)
+        if membership.role not in ('leader', 'admin'):
+            return error_list(NOT_AUTHORIZED)
+        serializer = NoticeSerializer(notice, data=request.data)
+        if serializer.is_valid(raise_exception=True):
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
 
-# 공지 삭제
-@require_POST
-@login_required
-def delete_notice(request):
-    study_id = request.POST.get("study_id")
-    notice_id = request.POST.get("notice_id")
-    user = request.user
-    study = get_object_or_404(Study, id=study_id)
-    notice = get_object_or_404(Notice, id=notice_id, study=study)
-    membership = StudyMembership.objects.filter(
-        user=user, study=study, is_active=True
-        ).first()
-    if not membership:
-        return JsonResponse(
-            {"error": "스터디 멤버가 아닙니다."},
-            status=403,
-            json_dumps_params={"ensure_ascii": False}
-        )
-    if membership.role not in ('leader', 'admin'):
-        return JsonResponse(
-            {"error": "삭제 권한이 없습니다."},
-            status=403,
-            json_dumps_params={"ensure_ascii": False}
-        )
-    notice.delete()
-    return JsonResponse(
-        {"message": "삭제되었습니다.",},
-        status = 200, json_dumps_params={"ensure_ascii": False}
-    )
+    # 공지사항 삭제
+    elif request.method == 'DELETE':
+        if membership.role not in ('leader', 'admin'):
+            return error_list(NOT_AUTHORIZED)
+        notice.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+# # 공지 수정
+# @require_POST
+# @login_required
+# def update_notice(request):
+#     study_id = request.POST.get("study_id")
+#     notice_id = request.POST.get("notice_id")
+#     user = request.user
+#     study = get_object_or_404(Study, id=study_id)
+#     notice = get_object_or_404(Notice, id=notice_id, study=study)
+#     membership = StudyMembership.objects.filter(
+#         user=user, study=study, is_active=True
+#         ).first()
+#     if not membership:
+#         return JsonResponse(
+#             {"error": "스터디 멤버가 아닙니다."},
+#             status=403,
+#             json_dumps_params={"ensure_ascii": False}
+#         )
+#     if membership.role not in ('leader', 'admin'):
+#         return JsonResponse(
+#             {"error": "공지사항 수정 권한이 없습니다."},
+#             status=403,
+#             json_dumps_params={"ensure_ascii": False}
+#         )
+#     # if notice.author != user:
+#     #     return JsonResponse(
+#     #         {"error": "본인만 수정 가능합니다."},
+#     #         status=403
+#     #     )
+#     form = NoticeCreationForm(request.POST, instance=notice)
+#     if form.is_valid():
+#         form.save()
+#         return JsonResponse(
+#             {
+#                 "message": "공지사항이 수정되었습니다.",
+#                 "notice":{
+#                     "id": notice.id,
+#                     "title": notice.title,
+#                     "content": notice.content,
+#                     "study": study.name,
+#                     "author": user.username,
+#                     "created_at": notice.created_at.strftime("%Y-%m-%d %H:%M"),
+#                     "updated_at": notice.updated_at.strftime("%Y-%m-%d %H:%M"),
+#                 }
+#             },
+#             status=200,
+#             json_dumps_params={"ensure_ascii": False}
+#         )
+#     else:
+#         return JsonResponse(
+#             {"error": form.errors},
+#             status=400,
+#             json_dumps_params={"ensure_ascii": False}
+#         )
+
+# # 공지 조회
+# @login_required
+# def read_notice(request):
+#     study_id = request.GET.get("study_id")
+#     notice_id = request.GET.get("notice_id")
+#     user = request.user
+#     study = get_object_or_404(Study, id=study_id)
+#     notice = get_object_or_404(Notice, id=notice_id, study=study)
+#     membership = StudyMembership.objects.filter(
+#         user=user, study=study, is_active=True
+#         ).first()
+#     if not membership:
+#         return JsonResponse({
+#             "error": "스터디 멤버가 아닙니다.",
+#         }, status=403, json_dumps_params={"ensure_ascii": False})
+
+#     return JsonResponse({
+#         "message": "조회 성공",
+#         "notice": {
+#             "id": notice.id,
+#             "title": notice.title,
+#             "content": notice.content,
+#             "study": study.name,
+#             "author": notice.author.username,
+#             "created_at": notice.created_at.strftime("%Y-%m-%d %H:%M"),
+#             "updated_at": notice.updated_at.strftime("%Y-%m-%d %H:%M"),
+#         }
+#     }, status=200, json_dumps_params={"ensure_ascii": False})
+
+# # 공지 삭제
+# @require_POST
+# @login_required
+# def delete_notice(request):
+#     study_id = request.POST.get("study_id")
+#     notice_id = request.POST.get("notice_id")
+#     user = request.user
+#     study = get_object_or_404(Study, id=study_id)
+#     notice = get_object_or_404(Notice, id=notice_id, study=study)
+#     membership = StudyMembership.objects.filter(
+#         user=user, study=study, is_active=True
+#         ).first()
+#     if not membership:
+#         return JsonResponse(
+#             {"error": "스터디 멤버가 아닙니다."},
+#             status=403,
+#             json_dumps_params={"ensure_ascii": False}
+#         )
+#     if membership.role not in ('leader', 'admin'):
+#         return JsonResponse(
+#             {"error": "삭제 권한이 없습니다."},
+#             status=403,
+#             json_dumps_params={"ensure_ascii": False}
+#         )
+#     notice.delete()
+#     return JsonResponse(
+#         {"message": "삭제되었습니다.",},
+#         status = 200, json_dumps_params={"ensure_ascii": False}
+#     )

--- a/Backend/studies/urls.py
+++ b/Backend/studies/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, include
 from . import views
 
 app_name = 'studies'
@@ -7,5 +7,8 @@ urlpatterns = [
     path('study/', views.study, name='study'),
     path('join/', views.join, name='join'),
     path('leave/', views.leave, name='leave'),
+    path('<int:study_id>', views.study_detail, name='study_detail'),
     path('study_list/', views.study_list, name='study_list'),
+    path('<int:study_id>/posts/', include('posts.urls')),
+    
 ]


### PR DESCRIPTION
- Post, Study API 호출 명 변경
	- `studies -> posts`의 계층적 구조로 변경
	- READ, UPDATE, DELETE의 경우 id를 Path Parameter로 받도록 변경
- Post CRUD 함수를 serializer 방식으로 변경, 아래 구조로 통합
	- Create
	- Read, Update, Delete