### PR TITLE
Use shared API client for authenticated requests

### DIFF
--- a/Frontend/Front/src/components/layout/Navbar.vue
+++ b/Frontend/Front/src/components/layout/Navbar.vue
@@ -335,7 +335,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import { useUiStore } from '@/stores/ui.ts'
 import { useUserStore } from '@/stores/user.ts'
 import { useStudiesStore } from '@/stores/studies.ts'
@@ -472,7 +472,7 @@ const submitCreate = async () => {
       name: create.value.form.title.trim(),
     }
 
-    await axios.post(`${API_BASE}/studies/study/`, payload, {
+    await client.post(`${API_BASE}/studies/study/`, payload, {
       withCredentials: true,
       headers: {
         'X-CSRFToken': csrftoken,
@@ -509,7 +509,7 @@ const submitJoin = async () => {
       id: join.value.code.trim(),
     }
 
-    await axios.post(`${API_BASE}/studies/join/`, payload, {
+    await client.post(`${API_BASE}/studies/join/`, payload, {
       withCredentials: true,
       headers: {
         'X-CSRFToken': csrftoken,

--- a/Frontend/Front/src/stores/studies.ts
+++ b/Frontend/Front/src/stores/studies.ts
@@ -2,6 +2,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import axios from 'axios'
+import client from '@/api/client'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors'
 import router from '@/router'
 
@@ -100,7 +101,7 @@ function parseAndSet(payload: unknown) {
       await ensureCsrf()
       const csrftoken = getCookie('csrftoken')
 
-      const { data } = await axios.get(`${API_BASE}/api/study_list/`, {
+      const { data } = await client.get(`${API_BASE}/api/study_list/`, {
         withCredentials: true,
         headers: { 'X-CSRFToken': csrftoken ?? '' },
       })

--- a/Frontend/Front/src/stores/studyRoleStore.ts
+++ b/Frontend/Front/src/stores/studyRoleStore.ts
@@ -1,7 +1,7 @@
 // src/stores/studyRoleStore.ts
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import axios from 'axios'
+import client from '@/api/client'
 const API_BASE = import.meta.env.VITE_API_BASE_URL as string
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors'
 
@@ -76,7 +76,7 @@ export const useStudyRoleStore = defineStore('studyRole', () => {
       await ensureCsrf()
       const csrftoken = getCookie('csrftoken')
 
-      const res = await axios.get(
+      const res = await client.get(
         `${API_BASE}/studies/${key}/get_my_role/`,
         {
           withCredentials: true,

--- a/Frontend/Front/src/views/MainPage.vue
+++ b/Frontend/Front/src/views/MainPage.vue
@@ -130,7 +130,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import AppShell from '@/layouts/AppShell.vue'
-import axios from 'axios'
+import client from '@/api/client'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors'
 import BaseScheduleCalendar from '@/components/BaseScheduleCalendar.vue'
 import type { EventInput, EventClickArg } from '@fullcalendar/core'
@@ -215,7 +215,7 @@ const loadSchedules = async () => {
     eventsMap.clear()
     detailError.value = ''
 
-    const allRes = await axios.get<Array<{ type: ScheduleType; data: CombinedData }>>(
+    const allRes = await client.get<Array<{ type: ScheduleType; data: CombinedData }>>(
       `${API_BASE}/schedules/schedule_list/`,
       {
         withCredentials: true,
@@ -357,7 +357,7 @@ const onSubmitCreate = async () => {
 
     if (isEditing.value && editingId.value !== null) {
       // ✅ 개인 일정 수정
-      await axios.put(
+      await client.put(
         `${API_BASE}/schedules/${editingId.value}/personal_schedule_detail/`,
         payload,
         {
@@ -370,7 +370,7 @@ const onSubmitCreate = async () => {
       )
     } else {
       // ✅ 개인 일정 생성
-      await axios.post(`${API_BASE}/schedules/personal_schedule_create/`, payload, {
+      await client.post(`${API_BASE}/schedules/personal_schedule_create/`, payload, {
         withCredentials: true,
         headers: {
           'X-CSRFToken': csrftoken || '',
@@ -428,7 +428,7 @@ const handleDeleteSchedule = async (id: number) => {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    await axios.delete(`${API_BASE}/schedules/${id}/personal_schedule_detail/`, {
+    await client.delete(`${API_BASE}/schedules/${id}/personal_schedule_detail/`, {
       withCredentials: true,
       headers: {
         'X-CSRFToken': csrftoken || '',

--- a/Frontend/Front/src/views/accounts/PasswordCheckPage.vue
+++ b/Frontend/Front/src/views/accounts/PasswordCheckPage.vue
@@ -37,7 +37,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import axios from 'axios'
+import client from '@/api/client'
 import { useRouter } from 'vue-router'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors.ts'
 
@@ -55,7 +55,7 @@ const onSubmit = async () => {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    const response = await axios.post(
+    const response = await client.post(
       `${API_BASE}/accounts/password-check/`,
       { password: password.value },
       {

--- a/Frontend/Front/src/views/settings/ProfilePage.vue
+++ b/Frontend/Front/src/views/settings/ProfilePage.vue
@@ -144,7 +144,7 @@
 <script setup>
 import SettingNavBar from '@/components/layout/SettingNavBar.vue'
 import { ref, onMounted } from 'vue'
-import axios from 'axios'
+import client from '@/api/client'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors.ts'
 import { useRouter } from 'vue-router'
 import * as bootstrap from 'bootstrap'
@@ -193,7 +193,7 @@ const onConfirmPassword = async () => {
     const params = new URLSearchParams()
     params.set('password', String(password.value).trim())
 
-    const res = await axios.post(
+    const res = await client.post(
       `${API_BASE}/accounts/check_password/`,
       params,
       {
@@ -227,7 +227,7 @@ const loadProfile = async () => {
     loading.value = true
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
-    const { data } = await axios.get(`${API_BASE}/accounts/search/`, {
+    const { data } = await client.get(`${API_BASE}/accounts/search/`, {
       withCredentials: true,
       headers: { 'X-CSRFToken': csrftoken },
     })

--- a/Frontend/Front/src/views/settings/ProfileUpdatePage.vue
+++ b/Frontend/Front/src/views/settings/ProfileUpdatePage.vue
@@ -152,11 +152,11 @@
 
 <script setup>
 /**
- * ✅ axios를 사용하는 페이지에서는 반드시 CSRF 유틸 import 필요
+ * ✅ client를 사용하는 페이지에서는 반드시 CSRF 유틸 import 필요
  */
 import SettingNavBar from '@/components/layout/SettingNavBar.vue'
 import { ref, computed, onMounted } from 'vue'
-import axios from 'axios'
+import client from '@/api/client'
 import { useRouter } from 'vue-router'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors'
 import { useUserStore } from '@/stores/user'
@@ -192,7 +192,7 @@ const loadProfile = async () => {
 
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
-    const { data } = await axios.get(`${API_BASE}/accounts/search/`, {
+    const { data } = await client.get(`${API_BASE}/accounts/search/`, {
       withCredentials: true,
       headers: { 'X-CSRFToken': csrftoken },
     })
@@ -279,7 +279,7 @@ const onSubmit = async () => {
     }
     if (avatarFile.value) fd.append('profile_img', avatarFile.value)
 
-    await axios.post(`${API_BASE}/accounts/update/`, fd, {
+    await client.post(`${API_BASE}/accounts/update/`, fd, {
       withCredentials: true,
       headers: { 'X-CSRFToken': csrftoken }, // FormData는 자동 Content-Type
     })

--- a/Frontend/Front/src/views/studies/StudyPage.vue
+++ b/Frontend/Front/src/views/studies/StudyPage.vue
@@ -218,7 +218,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import AppShell from '@/layouts/AppShell.vue'
 import BaseScheduleCalendar from '@/components/BaseScheduleCalendar.vue'
 import ScheduleDetailModal from '@/components/ScheduleDetailModal.vue'
@@ -430,7 +430,7 @@ async function fetchStudy() {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    const { data } = await axios.get(`${API_BASE}/studies/${studyId.value}/`, {
+    const { data } = await client.get(`${API_BASE}/studies/${studyId.value}/`, {
       withCredentials: true,
       headers: {
         'X-CSRFToken': csrftoken || '',
@@ -451,7 +451,7 @@ async function fetchSchedules() {
   try {
     await ensureCsrf()
 
-    const { data } = await axios.get<StudyScheduleItem[]>(
+    const { data } = await client.get<StudyScheduleItem[]>(
       `${API_BASE}/studies/${studyId.value}/schedules/study_schedule_list/`,
       {
         withCredentials: true,
@@ -496,7 +496,7 @@ async function fetchNotices() {
   try {
     await ensureCsrf()
 
-    const { data } = await axios.get<ApiNotice[]>(
+    const { data } = await client.get<ApiNotice[]>(
       `${API_BASE}/studies/${studyId.value}/posts/notice_list/`,
       {
         withCredentials: true,
@@ -526,7 +526,7 @@ async function fetchExams() {
   try {
     await ensureCsrf()
 
-    const { data } = await axios.get<any[]>(
+    const { data } = await client.get<any[]>(
       `${API_BASE}/studies/${studyId.value}/exams/`,
       {
         withCredentials: true,
@@ -555,7 +555,7 @@ async function fetchMembers() {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    const { data } = await axios.get<any[]>(
+    const { data } = await client.get<any[]>(
       `${API_BASE}/studies/${studyId.value}/member_list/`,
       {
         withCredentials: true,
@@ -676,7 +676,7 @@ async function openDetailModal(id: number) {
 
   try {
     await ensureCsrf()
-    const { data } = await axios.get<ScheduleDetailApi>(
+    const { data } = await client.get<ScheduleDetailApi>(
       `${API_BASE}/studies/${studyId.value}/schedules/${id}/study_schedule_detail/`,
       {
         withCredentials: true,
@@ -731,7 +731,7 @@ async function handleDetailDelete(id: number) {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    await axios.delete(
+    await client.delete(
       `${API_BASE}/studies/${studyId.value}/schedules/${id}/study_schedule_detail/`,
       {
         withCredentials: true,
@@ -795,7 +795,7 @@ async function handleLeaveStudy() {
     const csrftoken = getCookie('csrftoken')
 
     // 🔥 실제 "나가기" 엔드포인트로 수정 필요
-    await axios.post(
+    await client.post(
       `${API_BASE}/studies/leave/`,
       {
         id: studyId.value,
@@ -828,7 +828,7 @@ async function handleDissolveStudy() {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    await axios.delete(
+    await client.delete(
       `${API_BASE}/studies/${studyId.value}/study_delete/`,
       {
         withCredentials: true,
@@ -855,7 +855,7 @@ async function handleKickMember(memberId: number) {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    await axios.put(
+    await client.put(
       `${API_BASE}/studies/${studyId.value}/${memberId}/expel_member/`,
       {},
       {
@@ -880,7 +880,7 @@ async function handleChangeRole(memberId: number, role: StudyRole) {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    await axios.put(
+    await client.put(
       `${API_BASE}/studies/${studyId.value}/change_role/`,
       {
         target_id: memberId,

--- a/Frontend/Front/src/views/studies/exams/ExamEditorPage.vue
+++ b/Frontend/Front/src/views/studies/exams/ExamEditorPage.vue
@@ -265,7 +265,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors'
 import AppShell from '@/layouts/AppShell.vue'
 
@@ -359,7 +359,7 @@ const loadAiDraft = async () => {
   if (!props.draftId) return
 
   try {
-    const res = await axios.get(
+    const res = await client.get(
       `${API_BASE}/studies/${props.studyId}/exams/ai-draft/${props.draftId}/`,
       {
         withCredentials: true,
@@ -502,7 +502,7 @@ const submitExam = async () => {
       ai_draft_id: props.draftId,
     }
 
-    await axios.post(
+    await client.post(
       // ⬇️ 여기도 exams → exam 으로 수정
       `${API_BASE}/studies/${props.studyId}/exams/`,
       payload,

--- a/Frontend/Front/src/views/studies/exams/ExamTakePage.vue
+++ b/Frontend/Front/src/views/studies/exams/ExamTakePage.vue
@@ -96,7 +96,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 
 import AppShell from '@/layouts/AppShell.vue'
 import QuestionList from '@/views/studies/exams/components/QuestionList.vue'
@@ -216,7 +216,7 @@ async function fetchExamDetail() {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    const res = await axios.get<BackendExamDetail>(
+    const res = await client.get<BackendExamDetail>(
       `${API_BASE}/studies/${studyId.value}/exams/${examId.value}/`,
       {
         withCredentials: true,
@@ -276,7 +276,7 @@ async function submitExam() {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    await axios.post(
+    await client.post(
       `${API_BASE}/studies/${studyId.value}/exams/${examId.value}/submit/`,
       {
         answers: answers.value,

--- a/Frontend/Front/src/views/studies/exams/StudyExamsPage.vue
+++ b/Frontend/Front/src/views/studies/exams/StudyExamsPage.vue
@@ -136,7 +136,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import AppShell from '@/layouts/AppShell.vue'
 import ExamCreateModal from '@/views/studies/exams/components/ExamCreateModal.vue'
 import ExamResultModal from '@/views/studies/exams/components/ExamResultModal.vue'
@@ -255,7 +255,7 @@ const fetchExams = async () => {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    const res = await axios.get(`${API_BASE}/studies/${studyId}/exams/`, {
+    const res = await client.get(`${API_BASE}/studies/${studyId}/exams/`, {
       withCredentials: true,
       headers: {
         'X-CSRFToken': csrftoken,
@@ -306,7 +306,7 @@ const openResultModal = async (exam: ExamListItem) => {
 
     // 백엔드에 /my_result/ 같은 엔드포인트 구현 가정
     // 예: GET /studies/<study_id>/exams/<exam_id>/my_result/
-    const res = await axios.get(
+    const res = await client.get(
       `${API_BASE}/studies/${studyId}/exams/${exam.id}/my_result/`,
       {
         withCredentials: true,

--- a/Frontend/Front/src/views/studies/exams/components/ExamCreateModal.vue
+++ b/Frontend/Front/src/views/studies/exams/components/ExamCreateModal.vue
@@ -148,7 +148,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000'
@@ -242,7 +242,7 @@ const onSubmit = async () => {
       formData.append('context_file', file.value)
     }
 
-    const res = await axios.post(
+    const res = await client.post(
       `${API_BASE}/studies/${props.studyId}/exams/ai-generate/`,
       formData,
       {

--- a/Frontend/Front/src/views/studies/notice/NoticeCreatePage.vue
+++ b/Frontend/Front/src/views/studies/notice/NoticeCreatePage.vue
@@ -48,7 +48,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import AppShell from '@/layouts/AppShell.vue'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors.ts'
 
@@ -96,7 +96,7 @@ const handleUploadImg = async (files: File[], callback: (urls: string[]) => void
     for (const file of files) {
       const form = new FormData()
       form.append('image', file)
-      const res = await axios.post(
+      const res = await client.post(
         `${API_BASE}/studies/${studyId}/posts/upload_img/`,
         form,
         {
@@ -134,7 +134,7 @@ const submitNotice = async () => {
       content: markdown.value.trim(),
     }
 
-    const response = await axios.post(
+    const response = await client.post(
       `${API_BASE}/studies/${studyId}/posts/notice_create/`,
       payload,
       {

--- a/Frontend/Front/src/views/studies/notice/NoticeDetailPage.vue
+++ b/Frontend/Front/src/views/studies/notice/NoticeDetailPage.vue
@@ -103,7 +103,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import { MdPreview } from 'md-editor-v3'
 import AppShell from '@/layouts/AppShell.vue'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors.ts'
@@ -167,7 +167,7 @@ const onDelete = async () => {
   const csrftoken = getCookie('csrftoken')
 
   try {
-    await axios.delete(
+    await client.delete(
       `${API_BASE}/studies/${studyId}/posts/notice_detail/${noticeId}/`,
       {
         withCredentials: true,
@@ -201,7 +201,7 @@ onMounted(async () => {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    const res = await axios.get(
+    const res = await client.get(
       `${API_BASE}/studies/${studyId}/posts/notice_detail/${noticeId}/`,
       {
         withCredentials: true,

--- a/Frontend/Front/src/views/studies/notice/NoticeEditPage.vue
+++ b/Frontend/Front/src/views/studies/notice/NoticeEditPage.vue
@@ -82,7 +82,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import AppShell from '@/layouts/AppShell.vue'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors'
 import { MdEditor } from 'md-editor-v3'
@@ -119,7 +119,7 @@ const handleUploadImg = async (files: File[], callback: (urls: string[]) => void
       const form = new FormData()
       form.append('image', file)
 
-      const res = await axios.post(
+      const res = await client.post(
         `${API_BASE}/studies/${studyId}/posts/upload_img/`,
         form,
         {
@@ -154,7 +154,7 @@ const fetchNoticeDetail = async () => {
     isLoading.value = true
     await ensureCsrf()
 
-    const { data } = await axios.get(
+    const { data } = await client.get(
       `${API_BASE}/studies/${studyId}/posts/notice_detail/${noticeId}/`,
       {
         withCredentials: true,
@@ -196,7 +196,7 @@ const submitNotice = async () => {
       content: markdown.value.trim(),
     }
 
-    await axios.put(
+    await client.put(
       `${API_BASE}/studies/${studyId}/posts/notice_detail/${noticeId}/`,
       payload,
       {

--- a/Frontend/Front/src/views/studies/notice/StudyNoticePage.vue
+++ b/Frontend/Front/src/views/studies/notice/StudyNoticePage.vue
@@ -110,7 +110,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
-import axios from 'axios'
+import client from '@/api/client'
 import AppShell from '@/layouts/AppShell.vue'
 import { ensureCsrf, getCookie } from '@/utils/csrf_cors.ts'
 import { useStudyRoleStore } from '@/stores/studyRoleStore'
@@ -213,7 +213,7 @@ onMounted(async () => {
     await ensureCsrf()
     const csrftoken = getCookie('csrftoken')
 
-    const res = await axios.get<NoticeFromAPI[]>(
+    const res = await client.get<NoticeFromAPI[]>(
       `${API_BASE}/studies/${studyId}/posts/notice_list/`,
       {
         withCredentials: true,

--- a/Frontend/Front/src/views/studies/schedule/SchedulePage.vue
+++ b/Frontend/Front/src/views/studies/schedule/SchedulePage.vue
@@ -347,7 +347,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue"
 import { useRoute } from "vue-router"
-import axios from "axios"
+import client from '@/api/client'
 import AppShell from "@/layouts/AppShell.vue"
 import { ensureCsrf, getCookie } from "@/utils/csrf_cors"
 
@@ -629,7 +629,7 @@ const pastSchedules = computed<ScheduleItem[]>(() => {
 const fetchSchedules = async () => {
   try {
     isLoading.value = true
-    const res = await axios.get<ScheduleItem[]>(
+    const res = await client.get<ScheduleItem[]>(
       `${API_BASE}/studies/${studyId}/schedules/study_schedule_list/`,
       {
         withCredentials: true,
@@ -648,7 +648,7 @@ const onClickDelete = async (id: number) => {
     await ensureCsrf()
     const csrftoken = getCookie("csrftoken")
 
-    await axios.delete(
+    await client.delete(
       `${API_BASE}/studies/${studyId}/schedules/${id}/study_schedule_detail/`,
       {
         withCredentials: true,
@@ -673,7 +673,7 @@ const openDetailModal = async (id: number) => {
   detail.value = null
 
   try {
-    const res = await axios.get<ScheduleDetailResponse>(
+    const res = await client.get<ScheduleDetailResponse>(
       `${API_BASE}/studies/${studyId}/schedules/${id}/study_schedule_detail/`,
       {
         withCredentials: true,
@@ -851,7 +851,7 @@ const onSubmitCreate = async () => {
 
     if (isEditing.value && editingId.value !== null) {
       // 수정
-      await axios.put(
+      await client.put(
         `${API_BASE}/studies/${studyId}/schedules/${editingId.value}/study_schedule_detail/`,
         payload,
         {
@@ -864,7 +864,7 @@ const onSubmitCreate = async () => {
       )
     } else {
       // 생성
-      await axios.post(
+      await client.post(
         `${API_BASE}/studies/${studyId}/schedules/study_schedule_create/`,
         payload,
         {


### PR DESCRIPTION
## Summary
- replace authenticated axios calls with the shared API client across study, notice, exam, schedule, and account pages
- ensure each updated page imports the API client for consistent interceptor use

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a3337798083229a49bfcd24ea40b5)